### PR TITLE
Support true and false operands in noexcept specifiers

### DIFF
--- a/include/cppdecl/declarations/parse.h
+++ b/include/cppdecl/declarations/parse.h
@@ -2531,7 +2531,28 @@ namespace cppdecl
                         if (ConsumeWord(input, "noexcept"))
                         {
                             TrimLeadingWhitespace(input);
-                            func.noexcept_ = true;
+                            if (!ConsumePunctuation(input, "("))
+                            {
+                                func.noexcept_ = true;
+                            }
+                            else
+                            {
+                                TrimLeadingWhitespace(input);
+
+                                if (ConsumeWord(input, "true"))
+                                    func.noexcept_ = true;
+                                else if (!ConsumeWord(input, "false"))
+                                {
+                                    if (input.starts_with(')'))
+                                        return ParseError{.message = "Expected `true` or `false` in noexcept expression."};
+                                    return ParseError{.message = "Only `true` and `false` noexcept expressions are supported."};
+                                }
+
+                                TrimLeadingWhitespace(input);
+                                if (!ConsumePunctuation(input, ")"))
+                                    return ParseError{.message = "Expected `)` after noexcept expression."};
+                                TrimLeadingWhitespace(input);
+                            }
                             // Not trimming trailing whitespace here, it's not strictly necessary.
                         }
 

--- a/source/tests.cpp
+++ b/source/tests.cpp
@@ -766,6 +766,21 @@ int main()
     CheckRoundtrip("unsigned",                                 m_any, "unsigned");
     CheckRoundtrip("void foo() const volatile __restrict && noexcept", m_any, "void foo() const volatile __restrict && noexcept");
     CheckRoundtrip("auto foo() const volatile __restrict & noexcept -> int", m_any, "auto foo() const volatile __restrict & noexcept -> int");
+    CheckRoundtrip("void() noexcept", m_type, "void() noexcept");
+    CheckRoundtrip("void() noexcept(true)", m_type, "void() noexcept");
+    CheckRoundtrip("void() noexcept(false)", m_type, "void()");
+    CheckRoundtrip("void() noexcept( true )", m_type, "void() noexcept");
+    CheckRoundtrip("void() noexcept ( true )", m_type, "void() noexcept");
+    CheckRoundtrip("auto() noexcept(true) -> int", m_any, "auto() noexcept -> int");
+    CheckRoundtrip("auto() noexcept(false) -> int", m_any, "auto() -> int");
+    CheckRoundtrip("void(*)(int) noexcept(true)", m_type, "void (*)(int) noexcept");
+    CheckRoundtrip("void(* const)(int) noexcept( false )", m_type, "void (*const)(int)");
+    CheckRoundtrip("void(absl::internal_any_invocable::FunctionToCall, absl::internal_any_invocable::TypeErasedState*, absl::internal_any_invocable::TypeErasedState*) noexcept(true)", m_type, "void(absl::internal_any_invocable::FunctionToCall, absl::internal_any_invocable::TypeErasedState *, absl::internal_any_invocable::TypeErasedState *) noexcept");
+    CheckParseFail("void() noexcept(", m_type, 16, "Only `true` and `false` noexcept expressions are supported.");
+    CheckParseFail("void() noexcept()", m_type, 16, "Expected `true` or `false` in noexcept expression.");
+    CheckParseFail("void() noexcept(true", m_type, 20, "Expected `)` after noexcept expression.");
+    CheckParseFail("void() noexcept(value)", m_type, 16, "Only `true` and `false` noexcept expressions are supported.");
+    CheckParseFail("void() noexcept(true && false)", m_type, 21, "Expected `)` after noexcept expression.");
     CheckRoundtrip("auto() -> auto(*)(int) -> void",           m_any, "auto() -> auto (*)(int) -> void");
     CheckRoundtrip("auto() -> auto(*)(int) -> void",           m_any, "void (*())(int)", cppdecl::ToCodeFlags::force_no_trailing_return_type);
     CheckRoundtrip("int::A::*",                                m_any, "int (::A::*)"); // We could serialize this to `int ::A::*`, but it's easier to always add the `(...)` when the class name starts with `::`.


### PR DESCRIPTION
## Problem

Abseil LTS 20240722.0 defines its `AnyInvocable` manager function type using a conditional `noexcept` specifier:

```cpp
#define ABSL_INTERNAL_NOEXCEPT_SPEC(noex) noexcept(noex)

using ManagerType = void(FunctionToCall,
                         TypeErasedState*,
                         TypeErasedState*)
    ABSL_INTERNAL_NOEXCEPT_SPEC(true);
```

In C++17 and later this produces a function type ending in `noexcept(true)`.

The cppdecl function declarator parser previously consumed only the `noexcept` keyword. It left the parenthesized operand in the input, which was then parsed as another declarator and eventually caused:

```text
Function return type can't be a function.
```

## Changes

- Preserve the existing behavior for bare `noexcept`.
- Parse `noexcept(true)` as non-throwing.
- Parse `noexcept(false)` as potentially throwing.
- Accept whitespace around the parenthesized operand.
- Report stable errors for empty, unterminated, and unsupported operands.
- Preserve the existing normalized output:
  - `noexcept(true)` becomes `noexcept`.
  - `noexcept(false)` produces no `noexcept` specifier.

This change intentionally does not attempt to evaluate arbitrary C++ constant expressions. It only supports the evaluated boolean literals needed by compiler-produced type spellings.

## Tests

Added round-trip and rejection coverage for:

- bare `noexcept`;
- `noexcept(true)` and `noexcept(false)`;
- whitespace variations;
- trailing return types;
- function pointers;
- the complete Abseil `ManagerType` signature;
- empty, unterminated, identifier, and compound operands.

The test executable was compiled with MSVC in C++20 mode and completed successfully.